### PR TITLE
Remove optional chat provider

### DIFF
--- a/SETTINGS.md
+++ b/SETTINGS.md
@@ -8,10 +8,6 @@ Connect and configure these integrations:
     or
     [**Google Container Registry**](https://go.atomist.com/catalog/integration/google-container-registry "Google Container Registry (GCR)")
     _(required)_
-1.  [**Slack**](https://go.atomist.com/catalog/integration/slack "Slack Integration")
-    or
-    [**Microsoft Teams**](https://go.atomist.com/catalog/integration/microsoft-teams "Microsoft Teams Integration")
-    _(optional)_
 
 ## How to configure
 

--- a/skill.ts
+++ b/skill.ts
@@ -32,7 +32,6 @@ export const Skill = skill({
 
 	resourceProviders: {
 		github: resourceProvider.gitHub({ minRequired: 1 }),
-		slack: resourceProvider.chat(),
 		docker_push_registry: resourceProvider.dockerRegistry({
 			description: "Docker registry to push to",
 			displayName: "Push registry",


### PR DESCRIPTION
Just creating this PR to confirm that it is okay to remove the chat integration from a skill that creates chat messages.